### PR TITLE
Parse 'from' field in the commit line.

### DIFF
--- a/lib/Git/Repository/Log.pm
+++ b/lib/Git/Repository/Log.pm
@@ -7,7 +7,7 @@ use 5.006;
 # a few simple accessors
 for my $attr (
     qw(
-    commit tree
+    commit diff_from tree
     author author_name author_email
     committer committer_name committer_email
     author_localtime author_tz author_gmtime
@@ -41,7 +41,7 @@ sub new {
     }
 
     # special case
-    $self->{commit} = (split /\s/, $self->{commit} )[0];
+    ($self->{commit}, $self->{diff_from}) = $self->{commit} =~ /^(\S+)(?: \(from (\S+)\))?/;
 
     # compute other keys
     $self->{raw_message} = $self->{message};


### PR DESCRIPTION
When using '-m' option with combination with one of the diff options,
'git log' may produce several entries for the same commit sha1 comparing
commit to each of its parents, eg:

```
$ git log -m --name-status --abbrev-commit

commit 8b855a5 (from 2e9d45d)
Merge: 2e9d45d 464a9a0

    Merge branch 'bar'

A       baz
M       foo

commit 8b855a5 (from 464a9a0)
Merge: 2e9d45d 464a9a0

    Merge branch 'bar'

D       bar
A       baz
M       foo
```

This patch adds new field 'diff_from' to the log object, that will
contain parsed 'from' bit in the log entry header when available.
